### PR TITLE
Rename erroneously named to_snake_case

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -346,7 +346,7 @@ impl ToJson for ExecutionError {
 }
 
 #[doc(hidden)]
-pub fn to_snake_case(s: &str) -> String {
+pub fn to_camel_case(s: &str) -> String {
     let mut dest = String::new();
 
     for (i, part) in s.split('_').enumerate() {
@@ -369,14 +369,14 @@ pub fn to_snake_case(s: &str) -> String {
 }
 
 #[test]
-fn test_to_snake_case() {
-    assert_eq!(&to_snake_case("test")[..], "test");
-    assert_eq!(&to_snake_case("_test")[..], "Test");
-    assert_eq!(&to_snake_case("first_second")[..], "firstSecond");
-    assert_eq!(&to_snake_case("first_")[..], "first");
-    assert_eq!(&to_snake_case("a_b_c")[..], "aBC");
-    assert_eq!(&to_snake_case("a_bc")[..], "aBc");
-    assert_eq!(&to_snake_case("a_b")[..], "aB");
-    assert_eq!(&to_snake_case("a")[..], "a");
-    assert_eq!(&to_snake_case("")[..], "");
+fn test_to_camel_case() {
+    assert_eq!(&to_camel_case("test")[..], "test");
+    assert_eq!(&to_camel_case("_test")[..], "Test");
+    assert_eq!(&to_camel_case("first_second")[..], "firstSecond");
+    assert_eq!(&to_camel_case("first_")[..], "first");
+    assert_eq!(&to_camel_case("a_b_c")[..], "aBC");
+    assert_eq!(&to_camel_case("a_bc")[..], "aBc");
+    assert_eq!(&to_camel_case("a_b")[..], "aB");
+    assert_eq!(&to_camel_case("a")[..], "a");
+    assert_eq!(&to_camel_case("")[..], "");
 }

--- a/src/macros/args.rs
+++ b/src/macros/args.rs
@@ -27,7 +27,7 @@ macro_rules! __graphql__args {
         $name:ident $(= $default:tt)* : $ty:ty $(as $desc:tt)*, $($rest:tt)*
     ) => {
         let $name: $ty = $args
-            .get(&$crate::to_snake_case(stringify!($name)))
+            .get(&$crate::to_camel_case(stringify!($name)))
             .expect("Argument missing - validation must have failed");
         __graphql__args!(@assign_arg_vars, $args, $executorvar, $($rest)*);
     };
@@ -38,7 +38,7 @@ macro_rules! __graphql__args {
         $name:ident  $(= $default:tt)* : $ty:ty $(as $desc:expr)*
     ) => {
         let $name: $ty = $args
-            .get(&$crate::to_snake_case(stringify!($name)))
+            .get(&$crate::to_camel_case(stringify!($name)))
             .expect("Argument missing - validation must have failed");
     };
 
@@ -73,7 +73,7 @@ macro_rules! __graphql__args {
         $reg:expr, $base:expr, ( $name:ident = $default:tt : $t:ty )
     ) => {
         $base.argument($reg.arg_with_default::<$t>(
-            &$crate::to_snake_case(stringify!($name)),
+            &$crate::to_camel_case(stringify!($name)),
             &__graphql__args!(@as_expr, $default)))
     };
 
@@ -85,7 +85,7 @@ macro_rules! __graphql__args {
             @apply_args,
             $reg,
             $base.argument($reg.arg_with_default::<$t>(
-                &$crate::to_snake_case(stringify!($name)),
+                &$crate::to_camel_case(stringify!($name)),
                 &__graphql__args!(@as_expr, $default))),
             ( $($rest)* ))
     };
@@ -99,7 +99,7 @@ macro_rules! __graphql__args {
             @apply_args,
             $reg,
             $base.argument($reg.arg_with_default::<$t>(
-                &$crate::to_snake_case(stringify!($name)),
+                &$crate::to_camel_case(stringify!($name)),
                 &__graphql__args!(@as_expr, $default))
                 .description($desc)),
             ( $($rest)* ))
@@ -110,7 +110,7 @@ macro_rules! __graphql__args {
         $reg:expr, $base:expr, ( $name:ident : $t:ty )
     ) => {
         $base.argument($reg.arg::<$t>(
-            &$crate::to_snake_case(stringify!($name))))
+            &$crate::to_camel_case(stringify!($name))))
     };
 
     (
@@ -121,7 +121,7 @@ macro_rules! __graphql__args {
             @apply_args,
             $reg,
             $base.argument($reg.arg::<$t>(
-                &$crate::to_snake_case(stringify!($name)))),
+                &$crate::to_camel_case(stringify!($name)))),
             ( $($rest)* ))
     };
 
@@ -134,7 +134,7 @@ macro_rules! __graphql__args {
             $reg,
             $base.argument(
                 $reg.arg::<$t>(
-                    &$crate::to_snake_case(stringify!($name)))
+                    &$crate::to_camel_case(stringify!($name)))
                 .description($desc)),
             ( $($rest)* ))
     };

--- a/src/macros/field.rs
+++ b/src/macros/field.rs
@@ -68,7 +68,7 @@ macro_rules! __graphql__build_field_matches {
         ( $( ( $name:ident; ( $($args:tt)* ); $t:ty; $body:block ) )* ),
     ) => {
         $(
-            if $fieldvar == &$crate::to_snake_case(stringify!($name)) {
+            if $fieldvar == &$crate::to_camel_case(stringify!($name)) {
                 let result: $t = (|| {
                     __graphql__args!(
                         @assign_arg_vars,

--- a/src/macros/input_object.rs
+++ b/src/macros/input_object.rs
@@ -49,7 +49,7 @@ macro_rules! graphql_input_object {
     ) => {
         Some($name {
             $( $field_name: {
-                let n: String = $crate::to_snake_case(stringify!($field_name));
+                let n: String = $crate::to_camel_case(stringify!($field_name));
                 let v: Option<&&$crate::InputValue> = $var.get(&n[..]);
 
                 if let Some(v) = v {
@@ -84,7 +84,7 @@ macro_rules! graphql_input_object {
                     @apply_description,
                     $($descr)*,
                     $reg.arg::<$field_type>(
-                        &$crate::to_snake_case(stringify!($field_name))))
+                        &$crate::to_camel_case(stringify!($field_name))))
             ),*
         ]
     };

--- a/src/macros/interface.rs
+++ b/src/macros/interface.rs
@@ -100,7 +100,7 @@ macro_rules! graphql_interface {
             @apply_args,
             $reg,
             $reg.field_convert::<$t, _, Self::Context>(
-                &$crate::to_snake_case(stringify!($name)))
+                &$crate::to_camel_case(stringify!($name)))
                 .description($desc)
                 .deprecated($reason),
             $args));
@@ -118,7 +118,7 @@ macro_rules! graphql_interface {
             @apply_args,
             $reg,
             $reg.field_convert::<$t, _, Self::Context>(
-                &$crate::to_snake_case(stringify!($name)))
+                &$crate::to_camel_case(stringify!($name)))
                 .deprecated($reason),
             $args));
 
@@ -135,7 +135,7 @@ macro_rules! graphql_interface {
             @apply_args,
             $reg,
             $reg.field_convert::<$t, _, Self::Context>(
-                &$crate::to_snake_case(stringify!($name)))
+                &$crate::to_camel_case(stringify!($name)))
                 .description($desc),
             $args));
 
@@ -152,7 +152,7 @@ macro_rules! graphql_interface {
             @apply_args,
             $reg,
             $reg.field_convert::<$t, _, Self::Context>(
-                &$crate::to_snake_case(stringify!($name))),
+                &$crate::to_camel_case(stringify!($name))),
             $args));
 
         graphql_interface!(@ gather_meta, ($reg, $acc, $descr), $( $rest )*);

--- a/src/macros/object.rs
+++ b/src/macros/object.rs
@@ -238,7 +238,7 @@ macro_rules! graphql_object {
             @apply_args,
             $reg,
             $reg.field_convert::<$t, _, Self::Context>(
-                &$crate::to_snake_case(stringify!($name)))
+                &$crate::to_camel_case(stringify!($name)))
                 .description($desc)
                 .deprecated($reason),
             $args));
@@ -256,7 +256,7 @@ macro_rules! graphql_object {
             @apply_args,
             $reg,
             $reg.field_convert::<$t, _, Self::Context>(
-                &$crate::to_snake_case(stringify!($name)))
+                &$crate::to_camel_case(stringify!($name)))
                 .deprecated($reason),
             $args));
 
@@ -273,7 +273,7 @@ macro_rules! graphql_object {
             @apply_args,
             $reg,
             $reg.field_convert::<$t, _, Self::Context>(
-                &$crate::to_snake_case(stringify!($name)))
+                &$crate::to_camel_case(stringify!($name)))
                 .description($desc),
             $args));
 
@@ -290,7 +290,7 @@ macro_rules! graphql_object {
             @apply_args,
             $reg,
             $reg.field_convert::<$t, _, Self::Context>(
-                &$crate::to_snake_case(stringify!($name))),
+                &$crate::to_camel_case(stringify!($name))),
             $args));
 
         graphql_object!(@gather_object_meta, $reg, $acc, $descr, $ifaces, $( $rest )*);


### PR DESCRIPTION
This function is transforming snake_case to camelCase.

This may be considered a breaking change since the function is publicly exported, but it is hidden from the documentation.