### PR TITLE
Remove JSON wrapper object from GraphQLError::to_json

### DIFF
--- a/src/integrations/iron_handlers.rs
+++ b/src/integrations/iron_handlers.rs
@@ -108,11 +108,12 @@ impl<'a, CtxFactory, Query, Mutation, CtxT>
         let result = execute(query, None, &self.root_node, variables, &context);
 
         let content_type = "application/json".parse::<Mime>().unwrap();
+        let mut map = BTreeMap::new();
 
         match result {
             Ok((result, errors)) => {
-                let mut map = BTreeMap::new();
                 map.insert("data".to_owned(), result.to_json());
+
                 if !errors.is_empty() {
                     map.insert("errors".to_owned(), errors.to_json());
                 }
@@ -124,7 +125,9 @@ impl<'a, CtxFactory, Query, Mutation, CtxT>
             }
 
             Err(err) => {
-                let data = err.to_json();
+                map.insert("errors".to_owned(), err.to_json());
+
+                let data = Json::Object(map);
                 let json = data.pretty();
 
                 Ok(Response::with((content_type, status::BadRequest, json.to_string())))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,20 +286,16 @@ impl<'a> From<Spanning<ParseError<'a>>> for GraphQLError<'a> {
 
 impl<'a> ToJson for GraphQLError<'a> {
     fn to_json(&self) -> Json {
-        let errs = match *self {
+        match *self {
             GraphQLError::ParseError(ref err) => parse_error_to_json(err),
             GraphQLError::ValidationError(ref errs) => errs.to_json(),
             GraphQLError::MultipleOperationsProvided => Json::String(
-                "Must provide operation name if query contains multiple operations.".to_owned()),
+                "Must provide operation name if query contains multiple operations".to_owned()),
             GraphQLError::NoOperationProvided => Json::String(
                 "Must provide an operation".to_owned()),
             GraphQLError::UnknownOperationName => Json::String(
                 "Unknown operation".to_owned()),
-        };
-
-        Json::Object(vec![
-            ("errors".to_owned(), errs),
-        ].into_iter().collect())
+        }
     }
 }
 


### PR DESCRIPTION
This should be the responsibility of the caller and makes it consistent
with how the successful case is handled.