### PR TITLE
Fix graphQLFetcher body serialization

### DIFF
--- a/src/integrations/iron_handlers.rs
+++ b/src/integrations/iron_handlers.rs
@@ -189,10 +189,7 @@ impl Handler for GraphiQLHandler {
                         'Accept': 'application/json',
                         'Content-Type': 'application/json',
                     },
-                    body: JSON.stringify({
-                        query: params.query,
-                        variables: JSON.parse(params.variables || '{}')
-                    }),
+                    body: JSON.stringify(params)
                 }).then(function (response) {
                     return response.text();
                 }).then(function (body) {


### PR DESCRIPTION
`params.variables` is already an object when passed to the fetcher and
does not need to be parsed.