### PR TITLE
Update to iron 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,13 +23,13 @@ expose-test-schema = []
 
 [dependencies]
 rustc-serialize = { version = "^0.3.19", optional = true }
-iron = { version = "^0.4.0", optional = true }
+iron = { version = "^0.5.1", optional = true }
 serde = { version = "^0.9.1", optional = true }
 
 [dev-dependencies]
-iron = "^0.4.0"
-router = "^0.2.0"
-mount = "^0.2.1"
-logger = "^0.1.0"
-iron-test = "^0.4.0"
+iron = "^0.5.1"
+router = "^0.5.0"
+mount = "^0.3.0"
+logger = "^0.3.0"
+iron-test = "^0.5.0"
 bencher = "^0.1.2"

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -30,23 +30,13 @@ fn main() {
     mount.mount("/", graphiql_endpoint);
     mount.mount("/graphql", graphql_endpoint);
 
-    let mut chain = Chain::new(mount);
+    let (logger_before, logger_after) = Logger::new(None);
 
-    setup_logger(&mut chain);
+    let mut chain = Chain::new(mount);
+    chain.link_before(logger_before);
+    chain.link_after(logger_after);
 
     let host = env::var("LISTEN").unwrap_or("0.0.0.0:8080".to_owned());
     println!("GraphQL server started on {}", host);
     Iron::new(chain).http(host.as_str()).unwrap();
-}
-
-// Temporary fix - Iron's logger middleware does not work on Windows
-#[cfg(not(windows))]
-fn setup_logger(chain: &mut Chain) {
-    let (logger_before, logger_after) = Logger::new(None);
-    chain.link_before(logger_before);
-    chain.link_after(logger_after);
-}
-
-#[cfg(windows)]
-fn setup_logger(_: &mut Chain) {
 }

--- a/src/integrations/iron_handlers.rs
+++ b/src/integrations/iron_handlers.rs
@@ -5,6 +5,7 @@ use iron::middleware::Handler;
 use iron::mime::Mime;
 use iron::status;
 use iron::method;
+use iron::url::Url;
 
 use std::collections::BTreeMap;
 
@@ -59,7 +60,7 @@ impl<'a, CtxFactory, Query, Mutation, CtxT>
 
 
     fn handle_get(&self, req: &mut Request) -> IronResult<Response> {
-        let url = req.url.clone().into_generic_url();
+        let url: Url = req.url.clone().into();
 
         let mut query = None;
         let variables = Variables::new();


### PR DESCRIPTION
  * `Url::into_generic_url` was deprecated in 0.4.1. The `Into` trait is
    used instead.
  * iron/logger removed support for ANSI terminal colors in 0.2.0, which
    makes logging work in the Command Prompt on Windows.

Fixes #21