### PR TITLE
Fix a bunch of clippy warnings

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -168,7 +168,7 @@ impl<'a> Type<'a> {
     /// Only applies to named types; lists will return `None`.
     pub fn name(&self) -> Option<&str> {
         match *self {
-            Type::Named(ref n) | Type::NonNullNamed(ref n) => Some(n),
+            Type::Named(n) | Type::NonNullNamed(n) => Some(n),
             _ => None
         }
     }
@@ -178,7 +178,7 @@ impl<'a> Type<'a> {
     /// All type literals contain exactly one named type.
     pub fn innermost_name(&self) -> &str {
         match *self {
-            Type::Named(ref n) | Type::NonNullNamed(ref n) => n,
+            Type::Named(n) | Type::NonNullNamed(n) => n,
             Type::List(ref l) | Type::NonNullList(ref l) => l.innermost_name(),
         }
     }
@@ -195,8 +195,8 @@ impl<'a> Type<'a> {
 impl<'a> fmt::Display for Type<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Type::Named(ref n) => write!(f, "{}", n),
-            Type::NonNullNamed(ref n) => write!(f, "{}!", n),
+            Type::Named(n) => write!(f, "{}", n),
+            Type::NonNullNamed(n) => write!(f, "{}!", n),
             Type::List(ref t) => write!(f, "[{}]", t),
             Type::NonNullList(ref t) => write!(f, "[{}]!", t),
         }
@@ -237,7 +237,7 @@ impl InputValue {
     /// not contain any location information. Can be used from `ToInputValue`
     /// implementations, where no source code position information is available.
     pub fn list(l: Vec<InputValue>) -> InputValue {
-        InputValue::List(l.into_iter().map(|i| Spanning::unlocated(i)).collect())
+        InputValue::List(l.into_iter().map(Spanning::unlocated).collect())
     }
 
     /// Construct a located list.
@@ -371,7 +371,7 @@ impl InputValue {
             (&Variable(ref s1), &Variable(ref s2)) => s1 == s2,
             (&Boolean(b1), &Boolean(b2)) => b1 == b2,
             (&List(ref l1), &List(ref l2)) =>
-                l1.iter().zip(l2.iter()).all(|(ref v1, ref v2)| v1.item.unlocated_eq(&v2.item)),
+                l1.iter().zip(l2.iter()).all(|(v1, v2)| v1.item.unlocated_eq(&v2.item)),
             (&Object(ref o1), &Object(ref o2)) =>
                 o1.len() == o2.len()
                 && o1.iter()

--- a/src/integrations/iron_handlers.rs
+++ b/src/integrations/iron_handlers.rs
@@ -86,7 +86,7 @@ impl<'a, CtxFactory, Query, Mutation, CtxT>
         let mut query = None;
         let mut variables = Variables::new();
 
-        for (k, v) in json_obj.into_iter() {
+        for (k, v) in json_obj {
             if k == "query" {
                 query = v.as_string().map(|s| s.to_owned());
             }

--- a/src/macros/enums.rs
+++ b/src/macros/enums.rs
@@ -84,9 +84,9 @@ macro_rules! graphql_enum {
             }
 
             fn resolve(&self, _: Option<&[$crate::Selection]>, _: &$crate::Executor<Self::Context>) -> $crate::Value {
-                match self {
+                match *self {
                     $(
-                        &graphql_enum!(@as_pattern, $eval) =>
+                        graphql_enum!(@as_pattern, $eval) =>
                             $crate::Value::string(graphql_enum!(@as_expr, $ename)) ),*
                 }
             }
@@ -105,9 +105,9 @@ macro_rules! graphql_enum {
 
         impl $crate::ToInputValue for $name {
             fn to(&self) -> $crate::InputValue {
-                match self {
+                match *self {
                     $(
-                        &graphql_enum!(@as_pattern, $eval) =>
+                        graphql_enum!(@as_pattern, $eval) =>
                             $crate::InputValue::string(graphql_enum!(@as_expr, $ename)) ),*
                 }
             }

--- a/src/macros/field.rs
+++ b/src/macros/field.rs
@@ -69,7 +69,7 @@ macro_rules! __graphql__build_field_matches {
     ) => {
         $(
             if $fieldvar == &$crate::to_camel_case(stringify!($name)) {
-                let result: $t = (|| {
+                let result: $t = (||{
                     __graphql__args!(
                         @assign_arg_vars,
                         $argsvar, $executorvar, $($args)*

--- a/src/macros/interface.rs
+++ b/src/macros/interface.rs
@@ -191,7 +191,7 @@ macro_rules! graphql_interface {
         let $ctxtvar = &$ctxtarg;
 
         $(
-            if let Some(_) = $resolver as Option<$srctype> {
+            if ($resolver as Option<$srctype>).is_some() {
                 return (<$srctype as $crate::GraphQLType>::name()).unwrap().to_owned();
             }
         )*
@@ -208,7 +208,7 @@ macro_rules! graphql_interface {
         let $ctxtvar = &$execarg.context();
 
         $(
-            if $typenamearg == (<$srctype as $crate::GraphQLType>::name()).unwrap().to_owned() {
+            if $typenamearg == (<$srctype as $crate::GraphQLType>::name()).unwrap() {
                 return $execarg.resolve(&$resolver);
             }
         )*

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -469,7 +469,7 @@ impl<'a> Iterator for Lexer<'a> {
 impl<'a> fmt::Display for Token<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Token::Name(ref name) => write!(f, "{}", name),
+            Token::Name(name) => write!(f, "{}", name),
             Token::Int(i) => write!(f, "{}", i),
             Token::Float(v) => write!(f, "{}", v),
             Token::String(ref s) => write!(f, "\"{}\"", s.replace('\\', "\\\\").replace('"', "\\\"")),

--- a/src/parser/value.rs
+++ b/src/parser/value.rs
@@ -36,7 +36,7 @@ fn parse_list_literal<'a>(parser: &mut Parser<'a>, is_const: bool) -> ParseResul
             &Token::BracketOpen,
             |p| parse_value_literal(p, is_const),
             &Token::BracketClose
-        )).map(|items| InputValue::parsed_list(items)))
+        )).map(InputValue::parsed_list))
 }
 
 fn parse_object_literal<'a>(parser: &mut Parser<'a>, is_const: bool) -> ParseResult<'a, InputValue> {

--- a/src/schema/meta.rs
+++ b/src/schema/meta.rs
@@ -174,12 +174,12 @@ impl<'a> MetaType<'a> {
     /// Lists, non-null wrappers, and placeholders don't have names.
     pub fn name(&self) -> Option<&str> {
         match *self {
-            MetaType::Scalar(ScalarMeta { ref name, .. }) |
-            MetaType::Object(ObjectMeta { ref name, .. }) |
-            MetaType::Enum(EnumMeta { ref name, .. }) |
-            MetaType::Interface(InterfaceMeta { ref name, .. }) |
-            MetaType::Union(UnionMeta { ref name, .. }) |
-            MetaType::InputObject(InputObjectMeta { ref name, .. }) =>
+            MetaType::Scalar(ScalarMeta { name, .. }) |
+            MetaType::Object(ObjectMeta { name, .. }) |
+            MetaType::Enum(EnumMeta { name, .. }) |
+            MetaType::Interface(InterfaceMeta { name, .. }) |
+            MetaType::Union(UnionMeta { name, .. }) |
+            MetaType::InputObject(InputObjectMeta { name, .. }) =>
                 Some(name),
             _ => None,
         }
@@ -226,7 +226,7 @@ impl<'a> MetaType<'a> {
         match *self {
             MetaType::Object(ObjectMeta { ref fields, .. }) |
             MetaType::Interface(InterfaceMeta { ref fields, .. }) =>
-                fields.iter().filter(|f| f.name == name).next(),
+                fields.iter().find(|f| f.name == name),
             _ => None,
         }
     }
@@ -237,7 +237,7 @@ impl<'a> MetaType<'a> {
     pub fn input_field_by_name(&self, name: &str) -> Option<&Argument> {
         match *self {
             MetaType::InputObject(InputObjectMeta { ref input_fields, .. }) =>
-                input_fields.iter().filter(|f| f.name == name).next(),
+                input_fields.iter().find(|f| f.name == name),
             _ => None,
         }
     }
@@ -245,18 +245,18 @@ impl<'a> MetaType<'a> {
     /// Construct a `Type` literal instance based on the metadata
     pub fn as_type(&self) -> Type<'a> {
         match *self {
-            MetaType::Scalar(ScalarMeta { ref name, .. }) |
-            MetaType::Object(ObjectMeta { ref name, .. }) |
-            MetaType::Enum(EnumMeta { ref name, .. }) |
-            MetaType::Interface(InterfaceMeta { ref name, .. }) |
-            MetaType::Union(UnionMeta { ref name, .. }) |
-            MetaType::InputObject(InputObjectMeta { ref name, .. }) =>
+            MetaType::Scalar(ScalarMeta { name, .. }) |
+            MetaType::Object(ObjectMeta { name, .. }) |
+            MetaType::Enum(EnumMeta { name, .. }) |
+            MetaType::Interface(InterfaceMeta { name, .. }) |
+            MetaType::Union(UnionMeta { name, .. }) |
+            MetaType::InputObject(InputObjectMeta { name, .. }) =>
                 Type::NonNullNamed(name),
             MetaType::List(ListMeta { ref of_type }) =>
                 Type::NonNullList(Box::new(of_type.clone())),
             MetaType::Nullable(NullableMeta { ref of_type }) =>
                 match *of_type {
-                    Type::NonNullNamed(ref inner) => Type::Named(inner.to_owned()),
+                    Type::NonNullNamed(inner) => Type::Named(inner),
                     Type::NonNullList(ref inner) => Type::List(inner.clone()),
                     ref t => t.clone(),
                 },

--- a/src/schema/model.rs
+++ b/src/schema/model.rs
@@ -97,7 +97,7 @@ impl<'a> SchemaType<'a> {
         ];
 
         if let Some(root_type) = registry.types.get_mut(&query_type_name) {
-            if let &mut MetaType::Object(ObjectMeta { ref mut fields, .. }) = root_type {
+            if let MetaType::Object(ObjectMeta { ref mut fields, .. }) = *root_type {
                 fields.append(&mut meta_fields);
             }
             else {
@@ -171,13 +171,13 @@ impl<'a> SchemaType<'a> {
 
     pub fn make_type(&self, t: &Type) -> TypeType {
         match *t {
-            Type::NonNullNamed(ref n) =>
+            Type::NonNullNamed(n) =>
                 TypeType::NonNull(Box::new(
                     self.type_by_name(n).expect("Type not found in schema"))),
             Type::NonNullList(ref inner) =>
                 TypeType::NonNull(Box::new(
                     TypeType::List(Box::new(self.make_type(inner))))),
-            Type::Named(ref n) => self.type_by_name(n).expect("Type not found in schema"),
+            Type::Named(n) => self.type_by_name(n).expect("Type not found in schema"),
             Type::List(ref inner) =>
                 TypeType::List(Box::new(self.make_type(inner))),
         }
@@ -211,7 +211,7 @@ impl<'a> SchemaType<'a> {
                     .iter()
                     .flat_map(|t| self.concrete_type_by_name(t))
                     .collect(),
-            MetaType::Interface(InterfaceMeta { ref name, .. }) =>
+            MetaType::Interface(InterfaceMeta { name, .. }) =>
                 self.concrete_type_list()
                     .into_iter()
                     .filter(|t| match **t {
@@ -238,9 +238,9 @@ impl<'a> SchemaType<'a> {
         }
 
         match (super_type, sub_type) {
-            (&NonNullNamed(ref super_name), &NonNullNamed(ref sub_name)) |
-            (&Named(ref super_name), &Named(ref sub_name)) |
-            (&Named(ref super_name), &NonNullNamed(ref sub_name)) =>
+            (&NonNullNamed(super_name), &NonNullNamed(sub_name)) |
+            (&Named(super_name), &Named(sub_name)) |
+            (&Named(super_name), &NonNullNamed(sub_name)) =>
                 self.is_named_subtype(sub_name, super_name),
             (&NonNullList(ref super_inner), &NonNullList(ref sub_inner)) |
             (&List(ref super_inner), &List(ref sub_inner)) |
@@ -332,7 +332,7 @@ impl fmt::Display for DirectiveLocation {
 impl<'a> fmt::Display for TypeType<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            TypeType::Concrete(ref t) => f.write_str(&t.name().unwrap()),
+            TypeType::Concrete(t) => f.write_str(t.name().unwrap()),
             TypeType::List(ref i) => write!(f, "[{}]", i),
             TypeType::NonNull(ref i) => write!(f, "{}!", i),
         }

--- a/src/schema/schema.rs
+++ b/src/schema/schema.rs
@@ -125,7 +125,7 @@ graphql_object!(<'a> TypeType<'a>: SchemaType<'a> as "__Type" |&self| {
                 Some(schema.concrete_type_list()
                     .iter()
                     .filter_map(|&ct|
-                        if let &MetaType::Object(ObjectMeta { ref name, ref interface_names, .. }) = ct {
+                        if let MetaType::Object(ObjectMeta { ref name, ref interface_names, .. }) = *ct {
                             if interface_names.contains(&iface_name.to_owned()) {
                                 schema.type_by_name(name)
                             } else { None }
@@ -159,7 +159,7 @@ graphql_object!(<'a> Field<'a>: SchemaType<'a> as "__Field" |&self| {
     }
 
     field args() -> Vec<&Argument> {
-        self.arguments.as_ref().map_or_else(|| Vec::new(), |v| v.iter().collect())
+        self.arguments.as_ref().map_or_else(Vec::new, |v| v.iter().collect())
     }
 
     field type(&executor) -> TypeType {

--- a/src/validation/context.rs
+++ b/src/validation/context.rs
@@ -97,7 +97,7 @@ impl<'a> ValidatorContext<'a> {
             self.type_stack.push(None);
         }
 
-        self.type_literal_stack.push(t.map(|t| t.clone()));
+        self.type_literal_stack.push(t.cloned());
 
         let res = f(self);
 
@@ -131,7 +131,7 @@ impl<'a> ValidatorContext<'a> {
             self.input_type_stack.push(None);
         }
 
-        self.input_type_literal_stack.push(t.map(|t| t.clone()));
+        self.input_type_literal_stack.push(t.cloned());
 
         let res = f(self);
 

--- a/src/validation/multi_visitor.rs
+++ b/src/validation/multi_visitor.rs
@@ -17,7 +17,7 @@ impl<'a> MultiVisitor<'a> {
     }
 
     fn visit_all<F: FnMut(&mut Box<Visitor<'a> + 'a>) -> ()>(&mut self, mut f: F) {
-        for mut v in self.visitors.iter_mut() {
+        for mut v in &mut self.visitors {
             f(v);
         }
     }

--- a/src/validation/rules/arguments_of_correct_type.rs
+++ b/src/validation/rules/arguments_of_correct_type.rs
@@ -17,7 +17,7 @@ pub fn factory<'a>() -> ArgumentsOfCorrectType<'a> {
 impl<'a> Visitor<'a> for ArgumentsOfCorrectType<'a> {
     fn enter_directive(&mut self, ctx: &mut ValidatorContext<'a>, directive: &'a Spanning<Directive>) {
         self.current_args = ctx.schema
-            .directive_by_name(&directive.item.name.item)
+            .directive_by_name(directive.item.name.item)
             .map(|d| &d.arguments);
     }
 
@@ -27,7 +27,7 @@ impl<'a> Visitor<'a> for ArgumentsOfCorrectType<'a> {
 
     fn enter_field(&mut self, ctx: &mut ValidatorContext<'a>, field: &'a Spanning<Field>) {
         self.current_args = ctx.parent_type()
-            .and_then(|t| t.field_by_name(&field.item.name.item))
+            .and_then(|t| t.field_by_name(field.item.name.item))
             .and_then(|f| f.arguments.as_ref());
     }
 
@@ -37,13 +37,13 @@ impl<'a> Visitor<'a> for ArgumentsOfCorrectType<'a> {
 
     fn enter_argument(&mut self, ctx: &mut ValidatorContext<'a>, &(ref arg_name, ref arg_value): &'a (Spanning<&'a str>, Spanning<InputValue>)) {
         if let Some(argument_meta) = self.current_args
-            .and_then(|args| args.iter().filter(|a| a.name == arg_name.item).next())
+            .and_then(|args| args.iter().find(|a| a.name == arg_name.item))
         {
             let meta_type = ctx.schema.make_type(&argument_meta.arg_type);
 
-            if !is_valid_literal_value(&ctx.schema, &meta_type, &arg_value.item) {
+            if !is_valid_literal_value(ctx.schema, &meta_type, &arg_value.item) {
                 ctx.report_error(
-                    &error_message(&arg_name.item, &format!("{}", argument_meta.arg_type)),
+                    &error_message(arg_name.item, &format!("{}", argument_meta.arg_type)),
                     &[arg_value.start.clone()]);
             }
         }

--- a/src/validation/rules/default_values_of_correct_type.rs
+++ b/src/validation/rules/default_values_of_correct_type.rs
@@ -16,15 +16,15 @@ impl<'a> Visitor<'a> for DefaultValuesOfCorrectType {
         if let Some(Spanning { item: ref var_value, ref start, .. }) = var_def.default_value {
             if var_def.var_type.item.is_non_null() {
                 ctx.report_error(
-                    &non_null_error_message(&var_name.item, &format!("{}", var_def.var_type.item)),
+                    &non_null_error_message(var_name.item, &format!("{}", var_def.var_type.item)),
                     &[start.clone()])
             }
             else {
                 let meta_type = ctx.schema.make_type(&var_def.var_type.item);
 
-                if !is_valid_literal_value(&ctx.schema, &meta_type, var_value) {
+                if !is_valid_literal_value(ctx.schema, &meta_type, var_value) {
                     ctx.report_error(
-                        &type_error_message(&var_name.item, &format!("{}", var_def.var_type.item)),
+                        &type_error_message(var_name.item, &format!("{}", var_def.var_type.item)),
                         &[start.clone()]);
                 }
             }

--- a/src/validation/rules/fields_on_correct_type.rs
+++ b/src/validation/rules/fields_on_correct_type.rs
@@ -13,11 +13,11 @@ impl<'a> Visitor<'a> for FieldsOnCorrectType {
         {
             if let Some(parent_type) = context.parent_type() {
                 let field_name = &field.item.name;
-                let type_name = parent_type.name().clone().unwrap_or("<unknown>");
+                let type_name = parent_type.name().unwrap_or("<unknown>");
 
-                if parent_type.field_by_name(&field_name.item).is_none() {
+                if parent_type.field_by_name(field_name.item).is_none() {
                     context.report_error(
-                        &error_message(&field_name.item, &type_name),
+                        &error_message(field_name.item, type_name),
                         &[field_name.start.clone()]);
                 }
             }

--- a/src/validation/rules/fragments_on_composite_types.rs
+++ b/src/validation/rules/fragments_on_composite_types.rs
@@ -13,13 +13,13 @@ impl<'a> Visitor<'a> for FragmentsOnCompositeTypes {
         {
             if let Some(current_type) = context.current_type() {
                 if !current_type.is_composite() {
-                    let type_name = current_type.name().clone().unwrap_or("<unknown>");
+                    let type_name = current_type.name().unwrap_or("<unknown>");
                     let type_cond = &f.item.type_condition;
 
                     context.report_error(
                         &error_message(
-                            Some(&f.item.name.item.clone()),
-                            &type_name),
+                            Some(f.item.name.item),
+                            type_name),
                         &[type_cond.start.clone()]);
                 }
             }
@@ -31,12 +31,12 @@ impl<'a> Visitor<'a> for FragmentsOnCompositeTypes {
             if let Some(ref type_cond) = f.item.type_condition {
                 let invalid_type_name = context.current_type().iter()
                     .filter(|&t| !t.is_composite())
-                    .map(|t| t.name().clone().unwrap_or("<unknown>"))
+                    .map(|t| t.name().unwrap_or("<unknown>"))
                     .next();
 
                 if let Some(name) = invalid_type_name {
                     context.report_error(
-                        &error_message(None, &name),
+                        &error_message(None, name),
                         &[type_cond.start.clone()]);
                 }
             }

--- a/src/validation/rules/known_directives.rs
+++ b/src/validation/rules/known_directives.rs
@@ -67,7 +67,7 @@ impl<'a> Visitor<'a> for KnownDirectives {
 
         if let Some(directive_type) = ctx.schema.directive_by_name(directive_name) {
             if let Some(current_location) = self.location_stack.last() {
-                if directive_type.locations.iter().filter(|l| l == &current_location).next().is_none() {
+                if directive_type.locations.iter().find(|l| l == &current_location).is_none() {
                     ctx.report_error(
                         &misplaced_error_message(directive_name, current_location),
                         &[directive.start.clone()]);

--- a/src/validation/rules/known_fragment_names.rs
+++ b/src/validation/rules/known_fragment_names.rs
@@ -11,9 +11,9 @@ pub fn factory() -> KnownFragmentNames {
 impl<'a> Visitor<'a> for KnownFragmentNames {
     fn enter_fragment_spread(&mut self, context: &mut ValidatorContext<'a>, spread: &'a Spanning<FragmentSpread>) {
         let spread_name = &spread.item.name;
-        if !context.is_known_fragment(&spread_name.item) {
+        if !context.is_known_fragment(spread_name.item) {
             context.report_error(
-                &error_message(&spread_name.item),
+                &error_message(spread_name.item),
                 &[spread_name.start.clone()]);
         }
     }

--- a/src/validation/rules/known_type_names.rs
+++ b/src/validation/rules/known_type_names.rs
@@ -11,18 +11,18 @@ pub fn factory() -> KnownTypeNames {
 impl<'a> Visitor<'a> for KnownTypeNames {
     fn enter_inline_fragment(&mut self, ctx: &mut ValidatorContext<'a>, fragment: &'a Spanning<InlineFragment>) {
         if let Some(ref type_cond) = fragment.item.type_condition {
-            validate_type(ctx, &type_cond.item, &type_cond.start);
+            validate_type(ctx, type_cond.item, &type_cond.start);
         }
     }
 
     fn enter_fragment_definition(&mut self, ctx: &mut ValidatorContext<'a>, fragment: &'a Spanning<Fragment>) {
         let type_cond = &fragment.item.type_condition;
-        validate_type(ctx, &type_cond.item, &type_cond.start);
+        validate_type(ctx, type_cond.item, &type_cond.start);
     }
 
     fn enter_variable_definition(&mut self, ctx: &mut ValidatorContext<'a>, &(_, ref var_def): &'a (Spanning<&'a str>, VariableDefinition)) {
         let type_name = var_def.var_type.item.innermost_name();
-        validate_type(ctx, &type_name, &var_def.var_type.start);
+        validate_type(ctx, type_name, &var_def.var_type.start);
     }
 }
 

--- a/src/validation/rules/possible_fragment_spreads.rs
+++ b/src/validation/rules/possible_fragment_spreads.rs
@@ -18,16 +18,16 @@ impl<'a> Visitor<'a> for PossibleFragmentSpreads<'a> {
     fn enter_document(&mut self, ctx: &mut ValidatorContext<'a>, defs: &'a Document) {
         for def in defs {
             if let Definition::Fragment(Spanning { ref item, .. }) = *def {
-                if let Some(t) = ctx.schema.concrete_type_by_name(&item.type_condition.item) {
-                    self.fragment_types.insert(&item.name.item, t);
+                if let Some(t) = ctx.schema.concrete_type_by_name(item.type_condition.item) {
+                    self.fragment_types.insert(item.name.item, t);
                 }
             }
         }
     }
 
     fn enter_inline_fragment(&mut self, ctx: &mut ValidatorContext<'a>, frag: &'a Spanning<InlineFragment>) {
-        if let (Some(ref parent_type), Some(ref frag_type))
-            = (ctx.parent_type(), frag.item.type_condition.as_ref().and_then(|s| ctx.schema.concrete_type_by_name(&s.item)))
+        if let (Some(parent_type), Some(frag_type))
+            = (ctx.parent_type(), frag.item.type_condition.as_ref().and_then(|s| ctx.schema.concrete_type_by_name(s.item)))
         {
             if !ctx.schema.type_overlap(parent_type, frag_type) {
                 ctx.report_error(
@@ -41,13 +41,13 @@ impl<'a> Visitor<'a> for PossibleFragmentSpreads<'a> {
     }
 
     fn enter_fragment_spread(&mut self, ctx: &mut ValidatorContext<'a>, spread: &'a Spanning<FragmentSpread>) {
-        if let (Some(ref parent_type), Some(ref frag_type))
+        if let (Some(parent_type), Some(frag_type))
             = (ctx.parent_type(), self.fragment_types.get(spread.item.name.item))
         {
             if !ctx.schema.type_overlap(parent_type, frag_type) {
                 ctx.report_error(
                     &error_message(
-                        Some(&spread.item.name.item),
+                        Some(spread.item.name.item),
                         parent_type.name().unwrap_or("<unknown>"),
                         frag_type.name().unwrap_or("<unknown>")),
                     &[spread.start.clone()]);

--- a/src/validation/rules/unique_argument_names.rs
+++ b/src/validation/rules/unique_argument_names.rs
@@ -24,10 +24,10 @@ impl<'a> Visitor<'a> for UniqueArgumentNames<'a> {
     }
 
     fn enter_argument(&mut self, ctx: &mut ValidatorContext<'a>, &(ref arg_name, _): &'a (Spanning<&'a str>, Spanning<InputValue>)) {
-        match self.known_names.entry(&arg_name.item) {
+        match self.known_names.entry(arg_name.item) {
             Entry::Occupied(e) => {
                 ctx.report_error(
-                    &error_message(&arg_name.item),
+                    &error_message(arg_name.item),
                     &[e.get().clone(), arg_name.start.clone()]);
             }
             Entry::Vacant(e) => {

--- a/src/validation/rules/unique_fragment_names.rs
+++ b/src/validation/rules/unique_fragment_names.rs
@@ -16,10 +16,10 @@ pub fn factory<'a>() -> UniqueFragmentNames<'a> {
 
 impl<'a> Visitor<'a> for UniqueFragmentNames<'a> {
     fn enter_fragment_definition(&mut self, context: &mut ValidatorContext<'a>, f: &'a Spanning<Fragment>) {
-        match self.names.entry(&f.item.name.item) {
+        match self.names.entry(f.item.name.item) {
             Entry::Occupied(e) => {
                 context.report_error(
-                    &duplicate_message(&f.item.name.item),
+                    &duplicate_message(f.item.name.item),
                     &[e.get().clone(), f.item.name.start.clone()]);
             }
             Entry::Vacant(e) => {

--- a/src/validation/rules/unique_operation_names.rs
+++ b/src/validation/rules/unique_operation_names.rs
@@ -16,11 +16,11 @@ pub fn factory<'a>() -> UniqueOperationNames<'a> {
 
 impl<'a> Visitor<'a> for UniqueOperationNames<'a> {
     fn enter_operation_definition(&mut self, ctx: &mut ValidatorContext<'a>, op: &'a Spanning<Operation>) {
-        if let &Some(ref op_name) = &op.item.name {
-            match self.names.entry(&op_name.item) {
+        if let Some(ref op_name) = op.item.name {
+            match self.names.entry(op_name.item) {
                 Entry::Occupied(e) => {
                     ctx.report_error(
-                        &error_message(&op_name.item),
+                        &error_message(op_name.item),
                         &[e.get().clone(), op.start.clone()]);
                 }
                 Entry::Vacant(e) => {

--- a/src/validation/rules/unique_variable_names.rs
+++ b/src/validation/rules/unique_variable_names.rs
@@ -20,10 +20,10 @@ impl<'a> Visitor<'a> for UniqueVariableNames<'a> {
     }
 
     fn enter_variable_definition(&mut self, ctx: &mut ValidatorContext<'a>, &(ref var_name, _): &'a (Spanning<&'a str>, VariableDefinition)) {
-        match self.names.entry(&var_name.item) {
+        match self.names.entry(var_name.item) {
             Entry::Occupied(e) => {
                 ctx.report_error(
-                    &error_message(&var_name.item),
+                    &error_message(var_name.item),
                     &[e.get().clone(), var_name.start.clone()]);
             }
             Entry::Vacant(e) => {

--- a/src/validation/rules/variables_are_input_types.rs
+++ b/src/validation/rules/variables_are_input_types.rs
@@ -13,7 +13,7 @@ impl<'a> Visitor<'a> for UniqueVariableNames {
         if let Some(var_type) = ctx.schema.concrete_type_by_name(var_def.var_type.item.innermost_name()) {
             if !var_type.is_input() {
                 ctx.report_error(
-                    &error_message(&var_name.item, &format!("{}", var_def.var_type.item)),
+                    &error_message(var_name.item, &format!("{}", var_def.var_type.item)),
                     &[var_def.var_type.start.clone()]);
             }
         }


### PR DESCRIPTION
This PR fixes a bunch of [clippy](https://github.com/Manishearth/rust-clippy) warnings.
Clippy warnings aim to prevent bit rot and improve readability of the code.
Aside from some usages of the HashMap Entry-API these changes shouldn't affect compiled code.