### PR TITLE
Remove panic in Parser::next

### DIFF
--- a/src/parser/document.rs
+++ b/src/parser/document.rs
@@ -31,7 +31,7 @@ fn parse_definition<'a>(parser: &mut Parser<'a>) -> UnlocatedParseResult<'a, Def
             Ok(Definition::Operation(try!(parse_operation_definition(parser)))),
         Token::Name("fragment") =>
             Ok(Definition::Fragment(try!(parse_fragment_definition(parser)))),
-        _ => Err(parser.next().map(ParseError::UnexpectedToken)),
+        _ => Err(parser.next()?.map(ParseError::UnexpectedToken)),
     }
 }
 
@@ -130,7 +130,7 @@ fn parse_fragment<'a>(parser: &mut Parser<'a>) -> UnlocatedParseResult<'a, Selec
 
     match parser.peek().item {
         Token::Name("on") => {
-            parser.next();
+            parser.next()?;
             let name = try!(parser.expect_name());
             let directives = try!(parse_directives(parser));
             let selection_set = try!(parse_selection_set(parser));
@@ -185,7 +185,7 @@ fn parse_fragment<'a>(parser: &mut Parser<'a>) -> UnlocatedParseResult<'a, Selec
                         selection_set: selection_set.item,
                     })))
         },
-        _ => Err(parser.next().map(ParseError::UnexpectedToken)),
+        _ => Err(parser.next()?.map(ParseError::UnexpectedToken)),
     }
 }
 
@@ -244,9 +244,9 @@ fn parse_argument<'a>(parser: &mut Parser<'a>) -> ParseResult<'a, (Spanning<&'a 
 
 fn parse_operation_type<'a>(parser: &mut Parser<'a>) -> ParseResult<'a, OperationType> {
     match parser.peek().item {
-        Token::Name("query") => Ok(parser.next().map(|_| OperationType::Query)),
-        Token::Name("mutation") => Ok(parser.next().map(|_| OperationType::Mutation)),
-        _ => Err(parser.next().map(ParseError::UnexpectedToken))
+        Token::Name("query") => Ok(parser.next()?.map(|_| OperationType::Query)),
+        Token::Name("mutation") => Ok(parser.next()?.map(|_| OperationType::Mutation)),
+        _ => Err(parser.next()?.map(ParseError::UnexpectedToken))
     }
 }
 

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -108,8 +108,7 @@ impl<T> PartialEq for Spanning<T> where T: PartialEq + fmt::Debug {
     }
 }
 
-impl<T> Eq for Spanning<T> where T: Eq + fmt::Debug {
-}
+impl<T> Eq for Spanning<T> where T: Eq + fmt::Debug {}
 
 impl<T> Hash for Spanning<T> where T: Hash + fmt::Debug {
     fn hash<H: Hasher>(&self, state: &mut H) {

--- a/src/parser/value.rs
+++ b/src/parser/value.rs
@@ -8,11 +8,11 @@ pub fn parse_value_literal<'a>(parser: &mut Parser<'a>, is_const: bool) -> Parse
         Spanning { item: Token::CurlyOpen, .. } => parse_object_literal(parser, is_const),
         Spanning { item: Token::Dollar, .. } if !is_const => parse_variable_literal(parser),
         Spanning { item: Token::Int(i), .. } =>
-            Ok(parser.next().map(|_| InputValue::int(i))),
+            Ok(parser.next()?.map(|_| InputValue::int(i))),
         Spanning { item: Token::Float(f), .. } =>
-            Ok(parser.next().map(|_| InputValue::float(f))),
+            Ok(parser.next()?.map(|_| InputValue::float(f))),
         Spanning { item: Token::String(_), .. } =>
-            Ok(parser.next().map(|t|
+            Ok(parser.next()?.map(|t|
                 if let Token::String(s) = t {
                     InputValue::string(s)
                 }
@@ -20,14 +20,14 @@ pub fn parse_value_literal<'a>(parser: &mut Parser<'a>, is_const: bool) -> Parse
                     panic!("Internal parser error");
                 })),
         Spanning { item: Token::Name("true"), .. } =>
-            Ok(parser.next().map(|_| InputValue::boolean(true))),
+            Ok(parser.next()?.map(|_| InputValue::boolean(true))),
         Spanning { item: Token::Name("false"), .. } =>
-            Ok(parser.next().map(|_| InputValue::boolean(false))),
+            Ok(parser.next()?.map(|_| InputValue::boolean(false))),
         Spanning { item: Token::Name("null"), .. } =>
-            Ok(parser.next().map(|_| InputValue::null())),
+            Ok(parser.next()?.map(|_| InputValue::null())),
         Spanning { item: Token::Name(name), .. } =>
-            Ok(parser.next().map(|_| InputValue::enum_value(name.to_owned()))),
-        _ => Err(parser.next().map(ParseError::UnexpectedToken)),
+            Ok(parser.next()?.map(|_| InputValue::enum_value(name.to_owned()))),
+        _ => Err(parser.next()?.map(ParseError::UnexpectedToken)),
     }
 }
 


### PR DESCRIPTION
Hey,
I noticed this panic while passing invalid GraphQL queries to `juniper`.
I've moved it to the `ParseError::UnexpectedEndOfFile` error instead of panicking.