### PR TITLE
Avoid boxing in MultiVisitor

### DIFF
--- a/src/validation/mod.rs
+++ b/src/validation/mod.rs
@@ -14,7 +14,7 @@ pub use self::traits::Visitor;
 pub use self::visitor::visit;
 pub use self::context::{RuleError, ValidatorContext};
 pub use self::rules::visit_all_rules;
-pub use self::multi_visitor::MultiVisitor;
+pub use self::multi_visitor::{MultiVisitor, MultiVisitorNil};
 pub use self::input_value::validate_input_values;
 
 #[cfg(test)]

--- a/src/validation/rules/mod.rs
+++ b/src/validation/rules/mod.rs
@@ -24,36 +24,35 @@ mod variables_are_input_types;
 mod variables_in_allowed_position;
 
 use ast::Document;
-use validation::{ValidatorContext, MultiVisitor, visit};
+use validation::{ValidatorContext, MultiVisitor, MultiVisitorNil, visit};
 
 #[doc(hidden)]
 pub fn visit_all_rules<'a>(ctx: &mut ValidatorContext<'a>, doc: &'a Document) {
-    let mut mv = MultiVisitor::new(vec![
-        Box::new(self::arguments_of_correct_type::factory()),
-        Box::new(self::default_values_of_correct_type::factory()),
-        Box::new(self::fields_on_correct_type::factory()),
-        Box::new(self::fragments_on_composite_types::factory()),
-        Box::new(self::known_argument_names::factory()),
-        Box::new(self::known_directives::factory()),
-        Box::new(self::known_fragment_names::factory()),
-        Box::new(self::known_type_names::factory()),
-        Box::new(self::lone_anonymous_operation::factory()),
-        Box::new(self::no_fragment_cycles::factory()),
-        Box::new(self::no_undefined_variables::factory()),
-        Box::new(self::no_unused_fragments::factory()),
-        Box::new(self::no_unused_variables::factory()),
-        Box::new(self::overlapping_fields_can_be_merged::factory()),
-        Box::new(self::possible_fragment_spreads::factory()),
-        Box::new(self::provided_non_null_arguments::factory()),
-        Box::new(self::scalar_leafs::factory()),
-        Box::new(self::unique_argument_names::factory()),
-        Box::new(self::unique_fragment_names::factory()),
-        Box::new(self::unique_input_field_names::factory()),
-        Box::new(self::unique_operation_names::factory()),
-        Box::new(self::unique_variable_names::factory()),
-        Box::new(self::variables_are_input_types::factory()),
-        Box::new(self::variables_in_allowed_position::factory()),
-    ]);
+    let mut mv = MultiVisitorNil
+        .with(self::arguments_of_correct_type::factory())
+        .with(self::default_values_of_correct_type::factory())
+        .with(self::fields_on_correct_type::factory())
+        .with(self::fragments_on_composite_types::factory())
+        .with(self::known_argument_names::factory())
+        .with(self::known_directives::factory())
+        .with(self::known_fragment_names::factory())
+        .with(self::known_type_names::factory())
+        .with(self::lone_anonymous_operation::factory())
+        .with(self::no_fragment_cycles::factory())
+        .with(self::no_undefined_variables::factory())
+        .with(self::no_unused_fragments::factory())
+        .with(self::no_unused_variables::factory())
+        .with(self::overlapping_fields_can_be_merged::factory())
+        .with(self::possible_fragment_spreads::factory())
+        .with(self::provided_non_null_arguments::factory())
+        .with(self::scalar_leafs::factory())
+        .with(self::unique_argument_names::factory())
+        .with(self::unique_fragment_names::factory())
+        .with(self::unique_input_field_names::factory())
+        .with(self::unique_operation_names::factory())
+        .with(self::unique_variable_names::factory())
+        .with(self::variables_are_input_types::factory())
+        .with(self::variables_in_allowed_position::factory());
 
     visit(&mut mv, ctx, doc);
 }

--- a/src/validation/test_harness.rs
+++ b/src/validation/test_harness.rs
@@ -5,7 +5,7 @@ use executor::Registry;
 use types::scalars::{EmptyMutation, ID};
 use schema::model::{DirectiveType, DirectiveLocation, RootNode};
 use schema::meta::{EnumValue, MetaType};
-use validation::{Visitor, RuleError, ValidatorContext, MultiVisitor, visit};
+use validation::{Visitor, RuleError, ValidatorContext, MultiVisitor, MultiVisitorNil, visit};
 
 struct Being;
 struct Pet;
@@ -473,7 +473,7 @@ pub fn validate<'a, R, V, F>(r: R, q: &'a str, factory: F)
         unsafe { ::std::mem::transmute(&root.schema) },
         &doc);
 
-    let mut mv = MultiVisitor::new(vec![ Box::new(factory()) ]);
+    let mut mv = MultiVisitorNil.with(factory());
     visit(&mut mv, &mut ctx, unsafe { ::std::mem::transmute(&doc) });
 
     ctx.into_errors()


### PR DESCRIPTION
Get rid of all the boxing/heap allocations in `visit_all_rules`, and rely on a stack-allocated heterogenous linked list instead.

In my small GraphQL application (use-case is a high volume of rather simple queries), this brings me from about 17k to 20k rps. Working on getting some more detailed and relevant numbers, in the meantime I thought I'd already put this up for review.

Let me know what you think!