### PR TITLE
Improve best-case performance for to_camel_case

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,6 +203,8 @@ extern crate serde;
 
 #[cfg(any(feature="iron-handlers", feature="rocket-handlers"))] extern crate serde_json;
 
+use std::borrow::Cow;
+
 #[macro_use] mod macros;
 mod ast;
 pub mod parser;
@@ -296,22 +298,22 @@ impl<'a> From<Spanning<ParseError<'a>>> for GraphQLError<'a> {
 }
 
 #[doc(hidden)]
-pub fn to_camel_case(s: &str) -> String {
-    let mut dest = String::new();
+pub fn to_camel_case<'a>(s: &'a str) -> Cow<'a, str> {
+    let mut dest = Cow::Borrowed(s);
 
     for (i, part) in s.split('_').enumerate() {
         if i > 0 && part.len() == 1 {
-            dest.push_str(&part.to_uppercase());
+            dest += Cow::Owned(part.to_uppercase());
         }
         else if i > 0 && part.len() > 1 {
             let first = part.chars().next().unwrap().to_uppercase().collect::<String>();
             let second = &part[1..];
 
-            dest.push_str(&first);
-            dest.push_str(second);
+            dest += Cow::Owned(first);
+            dest += second;
         }
         else if i == 0 {
-            dest.push_str(part);
+            dest = Cow::Borrowed(part);
         }
     }
 

--- a/src/macros/input_object.rs
+++ b/src/macros/input_object.rs
@@ -64,7 +64,7 @@ macro_rules! graphql_input_object {
     ) => {
         Some($name {
             $( $field_name: {
-                let n: String = $crate::to_camel_case(stringify!($field_name));
+                let n = $crate::to_camel_case(stringify!($field_name));
                 let v: Option<&&$crate::InputValue> = $var.get(&n[..]);
 
                 match v {


### PR DESCRIPTION
For bigger schemas that leverage the `graphql_*` macros, `to_camel_case` is a major source of allocations.

This is because even if the compiler is able to fully evaluate the transformation at compile time, the program still needs to perform at least one allocation whenever `GraphQLType::resolve_field` is called.

This patch improves the best-case performance of `to_camel_case` using `Cow`, so that zero allocations and copies are necessary if no `_` are present in the field name (in my application this applies to most of the fields).