### PR TITLE
Try to avoid cloning in Value::object

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -48,10 +48,10 @@ impl Value {
 
     /// Construct an object value.
     pub fn object<K>(o: HashMap<K, Value>) -> Value
-        where K: AsRef<str> + Eq + Hash
+        where K: Into<String> + Eq + Hash
     {
         Value::Object(
-            o.into_iter().map(|(k, v)| (k.as_ref().to_owned(), v)).collect()
+            o.into_iter().map(|(k, v)| (k.into(), v)).collect()
         )
     }
 


### PR DESCRIPTION
Another bigger source of allocations: `Value::object` is often called with a `HashMap<String, Value`>, in which case calling `as_ref()` and `to_owned()` on the `String` will result in a needless copy.

Changing the required trait to `Into<String>` still works for `str` and `Cow<str>`, but ensures that `String` is not copied. 